### PR TITLE
Remove return value from StreamSignature __init__ in Signature inheri…

### DIFF
--- a/text/0002-interfaces.md
+++ b/text/0002-interfaces.md
@@ -204,7 +204,7 @@ Although some duplication was eliminated, some more remains: currently, it is ne
 ```python
 class StreamSignature(Signature):
     def __init__(self, payload_shape):
-        return super().__init__({
+        super().__init__({
             "payload": Out(payload_shape),
             "ready": In(1),
             "valid": Out(1)


### PR DESCRIPTION
…tance example (Python constructors don't return anything).

As [promised](https://libera.irclog.whitequark.org/amaranth-lang/2023-08-29#34839137;) :D. I did CTRL+F for `return`, and I believe this is the only `return` that should be removed.