### PR TITLE
Add RFC for fine-grained output enable for I/O buffers

### DIFF
--- a/text/0068-fine-grained-oe.md
+++ b/text/0068-fine-grained-oe.md
@@ -1,0 +1,68 @@
+- Start Date: (fill in with date at which the RFC is merged, YYYY-MM-DD)
+- RFC PR: [amaranth-lang/rfcs#0000](https://github.com/amaranth-lang/rfcs/pull/0000)
+- Amaranth Issue: [amaranth-lang/amaranth#0000](https://github.com/amaranth-lang/amaranth/issues/0000)
+
+# Fine-grained output enable
+
+## Summary
+[summary]: #summary
+
+Add an option to `lib.io.Buffer`, `lib.io.FFBuffer`, `lib.io.DDRBuffer` that makes `oe` have the same width as `i` and `o`, instead of always 1.
+
+## Motivation
+[motivation]: #motivation
+
+Certain interfaces (for example, dual-, quad-, octa-, and hexadeca-SPI) require individual control of some of the pins of a group in some of their operating modes. Although any library port (`lib.io.PortLike`) provided to an I/O module for such an interface can be split into several ports and several independent buffers may be used, it may still be useful to be generic over whether `oe` is per-port-wire or per-whole-port, as the buffer signatures are used not only directly, but when abstracting functionality as well. An example of a module that connects to an abstract buffer can be found [in the Glasgow project](https://github.com/whitequark/glasgow/blob/0104ff270c61ab7527207a54ed76c8898418988c/software/glasgow/gateware/iostream.py#L38), where currently an array of buffers is used instead.
+
+## Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+The `oe_common` parameter controls whether the `oe` member of `lib.io.Buffer.Signature`, `lib.io.FFBuffer.Signature`, and `lib.io.DDRBuffer.Signature` is common (1-wide) or per-wire (`width`-wide). Most interfaces only need common `oe`, which is the default option; per-wire `oe` is available to interfaces that need it.
+
+## Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+Several signatures from `lib.io` are extended with `oe_common=True` parameter:
+* `lib.io.Buffer.Signature`
+* `lib.io.FFBuffer.Signature`
+* `lib.io.DDRBuffer.Signature`
+
+If `oe_common == True`, then the existing behavior is preserved, with `len(oe) == 1`, and the value of `oe` is replicated across all wires.
+
+If `oe_common == False`, then `len(oe) == width`, and each bit of `oe` corresponds to each wire of the port.
+
+Internally, all of the platforms already instantiate per-wire fine-grained buffers and replicate `oe`, so this replication becomes optional if `oe_common == False`.
+
+To improve the health of the Amaranth standard I/O library (which will use this functionality for the QSPI flash controller), the changes are back-ported to the 0.5.x release branch.
+
+## Drawbacks
+[drawbacks]: #drawbacks
+
+* Bigger API surface; churn.
+* More complex documentation.
+    * The "Members" section for all signatures becomes quite ugly.
+* `lib.io.Buffer` is no longer an exact match to `hdl.IOBufferInstance`.
+    * `hdl.IOBufferInstance` could also be extended.
+
+## Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+* Do not do this.
+
+Since `lib.io.PortLike` objects can be sliced, and `lib.wiring` interfaces can include arrays of sub-interfaces, none of the functionality proposed in this RFC is essential. (In other words, it is possible to write a library-only wrapper with the proposed interface that delegates to the existing interface.) This RFC is only worth accepting if it seems valuable, going forward, to make all code operating on generic buffer interfaces be aware that `oe` is sometimes fine-grained.
+
+## Prior art
+[prior-art]: #prior-art
+
+Not applicable.
+
+## Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+- `oe_common` or `common_oe`?
+- Should `hdl.IOBufferInstance` also be updated?
+
+## Future possibilities
+[future-possibilities]: #future-possibilities
+
+None.


### PR DESCRIPTION
[Rendered](https://github.com/whitequark/amaranth-rfcs/blob/fine-grained-oe/text/0068-fine-grained-oe.md)